### PR TITLE
Freeswitch console fails to start when parent PID == 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY config/ /etc/freeswitch/
 # Don't expose any ports - use host networking
 
 # Run Freeswitch
-CMD stdbuf -i0 -o0 -e0 /usr/bin/freeswitch -c
+CMD ["stdbuf", "-i0", "-o0", "-e0", "freeswitch", "-c"]


### PR DESCRIPTION
```
[WARNING] switch_console.c:1053 We've become an orphan, no more console for us.
```

We run Freeswitch as the single process in the container ~~which means it gets PID 1~~. Freeswitch does not like this. It is not clear why. See [this](http://stackoverflow.com/questions/26939495/switch-console-c1053-weve-become-an-orphan-no-more-console-for-us) SO question.

~~A solution for now is to run Freeswitch from within a shell:
`/bin/bash -c 'freeswitch -c'`~~
Freeswitch _was_ being run from within `/bin/sh -c` which meant it's parent process was `/bin/sh` with PID == 1.
