### PR TITLE
Add an entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN mv /etc/freeswitch/directory/default/example.com.xml \
 # Set up the entrypoint
 COPY entrypoint.sh /usr/local/bin/freeswitch-entrypoint.sh
 ENTRYPOINT ["freeswitch-entrypoint.sh"]
-CMD ["-c", "-u" "freeswitch", "-g", "freeswitch"]
+CMD ["-c", "-u", "freeswitch", "-g", "freeswitch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,7 @@ RUN mv /etc/freeswitch/directory/default/example.com.xml \
 
 # Don't expose any ports - use host networking
 
-# Run Freeswitch
-CMD ["stdbuf", "-i0", "-o0", "-e0", "freeswitch", "-c"]
+# Set up the entrypoint
+COPY entrypoint.sh /usr/local/bin/freeswitch-entrypoint.sh
+ENTRYPOINT ["freeswitch-entrypoint.sh"]
+CMD ["-c", "-u" "freeswitch", "-g", "freeswitch"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,10 @@ if [ "${1:0:1}" = '-' ]; then
   set -- freeswitch "$@"
 fi
 
+# If we're running FreeSWITCH and are not in a terminal, then prevent FreeSWITCH
+# from buffering I/O for its CLI.
+if [ "$1" = 'freeswitch' ] && ! [ -t 1 ]; then
+  set -- stdbuf -i0 -o0 -e0 "$@"
+fi
+
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# First argument looks like an option for FreeSWITCH
+if [ "${1:0:1}" = '-' ]; then
+  set -- freeswitch "$@"
+fi
+
+exec "$@"

--- a/test.sh
+++ b/test.sh
@@ -37,6 +37,10 @@ trap "{ set +x; docker stop freeswitch; docker rm -f freeswitch; }" EXIT
 
 wait_for_log_line 'FreeSWITCH Started'
 
+# Check FreeSWITCH is run as the freeswitch user by default
+# Need to specify width of user field or else it gets truncated
+docker exec freeswitch ps ax --format 'user:10 pid command' | grep -E '^freeswitch .* freeswitch -c'
+
 # Check console colorize is disabled
 fs_cli_command console colorize | fgrep '+OK console color disabled'
 


### PR DESCRIPTION
* Run freeswitch as the user/group it creates on install

This primarily goes towards my goal of having as little as possible running as root inside containers. Given that FreeSWITCH is a big chunk of C++, I think this is particularly important.

This also just makes the entrypoint behaviour consistent with other images of ours as well as that of the official Docker images.

I _think_ it also fixes the CLI when doing a `docker run -it...`.