### PR TITLE
Install with --no-install-recommends, clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "deb http://files.freeswitch.org/repo/deb/freeswitch-1.6/ jessie main" 
 
 ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
 
-# Install Freeswitch (use regular apt-get install to avoid weird dependency problems)
+# Install Freeswitch
 RUN set -ex; \
     packages=' \
         freeswitch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN set -ex; \
         freeswitch-mod-shout \
     '; \
     apt-get update; \
-    apt-get -y --no-install-recommends install \
+    apt-get install -y --no-install-recommends \
         $(for package in $packages; do echo "$package=$FREESWITCH_VERSION"; done); \
+# Set of sound clips used in IVR menus. Not versioned like the other packages.
+    apt-get install -y --no-install-recommends freeswitch-sounds-en-us-callie; \
     rm -rf /var/lib/apt/lists/*
 
 # Copy basic configuration files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:jessie-slim
 LABEL maintainer "Praekelt.org <sre@praekelt.org>"
 
-# Add Freeswitch 1.6 repo
+# Add FreeSWITCH 1.6 repo
 RUN echo 'deb http://files.freeswitch.org/repo/deb/freeswitch-1.6 jessie main' \
         > /etc/apt/sources.list.d/freeswitch.list \
     && apt-key adv --keyserver pool.sks-keyservers.net --recv-key 20B06EE621AB150D40F6079FD76EDC7725E010CF
 
-# Install Freeswitch and necessary modules
+# Install FreeSWITCH and necessary modules
 ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
 RUN set -ex; \
     packages=' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,18 @@ RUN echo "deb http://files.freeswitch.org/repo/deb/freeswitch-1.6/ jessie main" 
 ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
 
 # Install Freeswitch (use regular apt-get install to avoid weird dependency problems)
-RUN apt-get update \
-    && apt-get -qy install \
-        freeswitch-meta-vanilla=$FREESWITCH_VERSION \
-        freeswitch-mod-flite=$FREESWITCH_VERSION \
-        freeswitch-mod-shout=$FREESWITCH_VERSION \
-    && rm -rf /var/lib/apt/lists/*
+RUN set -ex; \
+    packages=' \
+        freeswitch
+        freeswitch-conf-vanilla
+        freeswitch-meta-vanilla
+        freeswitch-mod-flite
+        freeswitch-mod-shout
+    '; \
+    apt-get update; \
+    apt-get -y --no-install-recommends install \
+        "$(for package in $packages; do echo "$package=$FREESWITCH_VERSION"; done)"; \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy basic configuration files
 RUN cp -a /usr/share/freeswitch/conf/vanilla/. /etc/freeswitch/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ RUN echo "deb http://files.freeswitch.org/repo/deb/freeswitch-1.6/ jessie main" 
         > /etc/apt/sources.list.d/freeswitch.list \
     && apt-key adv --keyserver pool.sks-keyservers.net --recv-key 20B06EE621AB150D40F6079FD76EDC7725E010CF
 
-ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
+# Set of sound clips used in IVR menus. Not versioned like the other packages.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends freeswitch-sounds-en-us-callie \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Freeswitch
+ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
 RUN set -ex; \
     packages=' \
         freeswitch \
@@ -20,8 +24,6 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         $(for package in $packages; do echo "$package=$FREESWITCH_VERSION"; done); \
-# Set of sound clips used in IVR menus. Not versioned like the other packages.
-    apt-get install -y --no-install-recommends freeswitch-sounds-en-us-callie; \
     rm -rf /var/lib/apt/lists/*
 
 # Copy basic configuration files

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ RUN echo "deb http://files.freeswitch.org/repo/deb/freeswitch-1.6/ jessie main" 
         > /etc/apt/sources.list.d/freeswitch.list \
     && apt-key adv --keyserver pool.sks-keyservers.net --recv-key 20B06EE621AB150D40F6079FD76EDC7725E010CF
 
-# Set of sound clips used in IVR menus. Not versioned like the other packages.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends freeswitch-sounds-en-us-callie \
-    && rm -rf /var/lib/apt/lists/*
-
 # Install Freeswitch
 ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
 RUN set -ex; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex; \
     '; \
     apt-get update; \
     apt-get -y --no-install-recommends install \
-        "$(for package in $packages; do echo "$package=$FREESWITCH_VERSION"; done)"; \
+        $(for package in $packages; do echo "$package=$FREESWITCH_VERSION"; done); \
     rm -rf /var/lib/apt/lists/*
 
 # Copy basic configuration files

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
 # Install Freeswitch (use regular apt-get install to avoid weird dependency problems)
 RUN set -ex; \
     packages=' \
-        freeswitch
-        freeswitch-conf-vanilla
-        freeswitch-meta-vanilla
-        freeswitch-mod-flite
-        freeswitch-mod-shout
+        freeswitch \
+        freeswitch-conf-vanilla \
+        freeswitch-meta-vanilla \
+        freeswitch-mod-flite \
+        freeswitch-mod-shout \
     '; \
     apt-get update; \
     apt-get -y --no-install-recommends install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM debian:jessie-slim
 LABEL maintainer "Praekelt.org <sre@praekelt.org>"
 
 # Add Freeswitch 1.6 repo
-RUN echo "deb http://files.freeswitch.org/repo/deb/freeswitch-1.6/ jessie main" \
+RUN echo 'deb http://files.freeswitch.org/repo/deb/freeswitch-1.6 jessie main' \
         > /etc/apt/sources.list.d/freeswitch.list \
     && apt-key adv --keyserver pool.sks-keyservers.net --recv-key 20B06EE621AB150D40F6079FD76EDC7725E010CF
 
-# Install Freeswitch
+# Install Freeswitch and necessary modules
 ENV FREESWITCH_VERSION 1.6.20~37~987c9b9-1~jessie+1
 RUN set -ex; \
     packages=' \
@@ -21,11 +21,11 @@ RUN set -ex; \
         $(for package in $packages; do echo "$package=$FREESWITCH_VERSION"; done); \
     rm -rf /var/lib/apt/lists/*
 
-# Copy basic configuration files
+# Copy the "vanilla" configuration files
 RUN cp -a /usr/share/freeswitch/conf/vanilla/. /etc/freeswitch/
 COPY config/ /etc/freeswitch/
 
-# Disable the example gateway
+# Disable the example gateway and the IPv6 SIP profiles
 RUN set -ex; \
     cd /etc/freeswitch; \
     mv directory/default/example.com.xml directory/default/example.com.xml.noload; \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ docker exec -it freeswitch fs_cli
 This is NOT a complete FreeSWITCH installation - the Docker image only contains the "meta-vanilla" packages as well as a couple of extra modules. FreeSWITCH is a very large software project with many submodules. We install only the features that *we* need. Still, this may be a useful starting point for anybody looking to run FreeSWITCH under Docker.
 
 We install the following FreeSWITCH packages:
+* `freeswitch-conf-vanilla`
 * `freeswitch-meta-vanilla`
 * `freeswitch-mod-flite` (for text-to-speech)
 * `freeswitch-mod-shout` (for playing audio from files)


### PR DESCRIPTION
Before: 771MB
After: 173MB

The `freeswitch-meta-vanilla` package installs a _lot_ of extra stuff as recommended packages. I think the main thing that takes up a lot of space is a set of default audio files generated at several sampling rates. I spoke to @DevChima and it seems like we don't use those audio clips.

I'm _reasonably_ confident that all the modules we need are included, but we may have to try this out to see.